### PR TITLE
部分適用がない範囲でコード生成を実装 #6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "cc"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+
+[[package]]
 name = "cexpr"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +216,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "inkwell"
+version = "0.1.0"
+source = "git+https://github.com/TheDan64/inkwell?branch=master#45d4dcbeabb8b3c074ef40aeb0e816704c293f31"
+dependencies = [
+ "either",
+ "inkwell_internals",
+ "libc",
+ "llvm-sys",
+ "once_cell",
+ "parking_lot",
+ "regex",
+]
+
+[[package]]
+name = "inkwell_internals"
+version = "0.4.0"
+source = "git+https://github.com/TheDan64/inkwell?branch=master#45d4dcbeabb8b3c074ef40aeb0e816704c293f31"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
 
 [[package]]
 name = "libloading"
@@ -273,6 +312,28 @@ checksum = "c0cf036d15402bea3c5d4de17b3fce76b3e4a56ebc1f577be0e7a72f7c607cf0"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "llvm-sys"
+version = "120.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a810627ac62b396f5fd2214ba9bbd8748d4d6efdc4d2c1c1303ea7a75763ce"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex",
+ "semver",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
 ]
 
 [[package]]
@@ -317,6 +378,31 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
 
 [[package]]
 name = "peeking_take_while"
@@ -485,6 +571,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +611,12 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
+name = "smallvec"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "strsim"
@@ -638,6 +754,7 @@ name = "yil"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "inkwell",
  "itertools",
  "lexpr",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ tempfile = "3"
 itertools = "0.10"
 once_cell = "1.8.0"
 z3 = "0.11.2"
+inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm12-0"] }

--- a/example-codes/well-typed/constant.yil
+++ b/example-codes/well-typed/constant.yil
@@ -1,1 +1,1 @@
-rec func hoge (x: int | true): (y: int | true) = 42
+rec func main (x: int | true): (y: int | true) = 42

--- a/example-codes/well-typed/even_odd.yil
+++ b/example-codes/well-typed/even_odd.yil
@@ -9,3 +9,6 @@ rec func is_odd (n:int | n >= 0) :
   
   ifz n { 1 }
   else { is_even (n - 1) }
+
+ rec func main (a:int | true): (ret:int | true) =
+   is_even 42

--- a/example-codes/well-typed/even_odd.yil
+++ b/example-codes/well-typed/even_odd.yil
@@ -1,14 +1,15 @@
 rec func is_even (n:int | n >= 0) :
-  (ret: int | ((n % 2 = 0) => ret = 0) && ((n %2 != 0) => ret = 1)) =
+  (ret: int | ((n % 2 = 0) => ret = true) && ((n %2 != 0) => ret = false)) =
 
   ifz n { 0 }
   else { is_odd (n - 1) }
 
 rec func is_odd (n:int | n >= 0) :
-  (ret: int | ((n % 2 = 0) => ret = 1) && ((n %2 != 0) => ret = 0)) =
+  (ret: int | ((n % 2 = 0) => ret = false) && ((n %2 != 0) => ret = true)) =
   
   ifz n { 1 }
   else { is_even (n - 1) }
 
- rec func main (a:int | true): (ret:int | true) =
-   is_even 42
+func main (a:int | true): (ret:int | true) =
+   let unused = print_bool (is_even 42) in
+   0

--- a/example-codes/well-typed/func_call.yil
+++ b/example-codes/well-typed/func_call.yil
@@ -1,1 +1,1 @@
-rec func hoge (x: int | true): (y: int | true) = hoge x
+rec func main (x: int | true): (y: int | true) = main x

--- a/example-codes/well-typed/if-func-branch.yil
+++ b/example-codes/well-typed/if-func-branch.yil
@@ -2,7 +2,7 @@ rec func hoge (x: int | x >= 1): (y: int | y >= 2) = x + 1
 
 rec func fuga (x: int | x >= -1): (y: int | y >= 3) = x + 4
 
-rec func piyo (x: int | true): (f: (x_1: int | x_1 >= 1) -> (y: int | y >= 3)) =
+rec func main (x: int | true): (f: (x_1: int | x_1 >= 1) -> (y: int | y >= 3)) =
   ifz x { hoge }
   else { fuga }
 

--- a/example-codes/well-typed/let.yil
+++ b/example-codes/well-typed/let.yil
@@ -1,3 +1,3 @@
-rec func hoge (a:int | a >= 0) : (x:int | x >= 1) =
+rec func main (a:int | a >= 0) : (x:int | x >= 1) =
     let b = a in
     b + 1

--- a/example-codes/well-typed/nested-binop.yil
+++ b/example-codes/well-typed/nested-binop.yil
@@ -1,2 +1,2 @@
-rec func hoge (a: int | true): (ret: int | ret = 0) =
+rec func main (a: int | true): (ret: int | ret = 0) =
     (1 + 2) >= 3

--- a/example-codes/well-typed/sum.yil
+++ b/example-codes/well-typed/sum.yil
@@ -1,3 +1,5 @@
-rec func sum (n:int | n = 0) : (m:int | 2 * m = n * (n+1)) =
+rec func sum (n:int | n >= 0) : (m:int | 2 * m = n * (n+1)) =
   ifz n { 0 }
   else { n + sum (n - 1) }
+
+func main (a:int | true) : (ret:int | true) = sum 3

--- a/example-codes/well-typed/valid.yil
+++ b/example-codes/well-typed/valid.yil
@@ -1,1 +1,1 @@
-rec func hoge (x:int | x >= 0) : (y:int | y >= x + 1) = x + 2
+rec func main (x:int | x >= 0) : (y:int | y >= x + 1) = x + 2

--- a/example-codes/well-typed/variable.yil
+++ b/example-codes/well-typed/variable.yil
@@ -1,1 +1,1 @@
-rec func hoge (x: int | x >= 10 ): (y: int | y >= 3) = x
+rec func main (x: int | x >= 10 ): (y: int | y >= 3) = x

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -89,6 +89,14 @@ impl Ident {
     }
 
     #[cfg(test)]
+    pub fn builtin_ident_with_id(id: usize) -> Self {
+        Self {
+            id,
+            is_builtin: true,
+        }
+    }
+
+    #[cfg(test)]
     pub fn current_count() -> usize {
         FRESH_IDENT_COUNT.load(SeqCst)
     }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -225,6 +225,29 @@ impl From<Type> for SimpleType {
     }
 }
 
+impl SimpleType {
+    pub fn is_func(&self) -> bool {
+        match self {
+            SimpleType::FuncType(_, _) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_int(&self) -> bool {
+        match self {
+            SimpleType::IntType => true,
+            _ => false,
+        }
+    }
+
+    pub fn as_func(&self) -> (&SimpleType, &SimpleType) {
+        match self {
+            SimpleType::FuncType(type1, type2) => (type1, type2),
+            _ => unreachable!(),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct Func {
     pub typ: Type,

--- a/src/ast/builtin.rs
+++ b/src/ast/builtin.rs
@@ -21,6 +21,7 @@ pub struct BuiltinData {
     pub mult_ident: Ident,
     pub div_ident: Ident,
     pub rem_ident: Ident,
+    pub print_bool_ident: Ident,
 }
 
 impl std::iter::IntoIterator for &BuiltinData {
@@ -41,6 +42,7 @@ impl std::iter::IntoIterator for &BuiltinData {
             self.mult_ident,
             self.div_ident,
             self.rem_ident,
+            self.print_bool_ident,
         ]
         .into_iter()
     }
@@ -62,6 +64,7 @@ impl BuiltinData {
             mult_ident: Ident::builtin_fresh(),
             div_ident: Ident::builtin_fresh(),
             rem_ident: Ident::builtin_fresh(),
+            print_bool_ident: Ident::builtin_fresh(),
         })
     }
 
@@ -93,6 +96,8 @@ impl BuiltinData {
             Some("/")
         } else if inst.rem_ident == ident {
             Some("%")
+        } else if inst.print_bool_ident == ident {
+            Some("print_bool")
         } else {
             None
         }
@@ -126,6 +131,8 @@ fn simple_type_of(ident: Ident) -> Option<SimpleType> {
             Box::new(SimpleType::IntType),
         )),
     );
+    let print_bool_simple_type =
+        SimpleType::FuncType(Box::new(SimpleType::IntType), Box::new(SimpleType::IntType));
     Some(if inst.or_ident == ident {
         binop_simple_type
     } else if inst.and_ident == ident {
@@ -152,6 +159,8 @@ fn simple_type_of(ident: Ident) -> Option<SimpleType> {
         binop_simple_type
     } else if inst.rem_ident == ident {
         binop_simple_type
+    } else if inst.print_bool_ident == ident {
+        print_bool_simple_type
     } else {
         return None;
     })
@@ -159,6 +168,27 @@ fn simple_type_of(ident: Ident) -> Option<SimpleType> {
 
 fn type_of(ident: Ident) -> Option<Type> {
     let inst = BuiltinData::instance();
+
+    if inst.print_bool_ident == ident {
+        let func_ident = Ident::builtin_fresh();
+        let arg_ident = Ident::builtin_fresh();
+        let ret_ident = Ident::builtin_fresh();
+        return Some(Type::FuncType(
+            func_ident,
+            Box::new(Type::IntType(
+                arg_ident,
+                Term::True(Info::Dummy),
+                Info::Dummy,
+            )),
+            Box::new(Type::IntType(
+                ret_ident,
+                Term::True(Info::Dummy),
+                Info::Dummy,
+            )),
+            Info::Dummy,
+        ));
+    }
+
     let arg1_ident = Ident::builtin_fresh();
     let arg2_ident = Ident::builtin_fresh();
     let ret_ident = Ident::builtin_fresh();

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,0 +1,344 @@
+use std::convert::TryInto;
+
+use inkwell::{
+    builder::Builder,
+    context::Context,
+    module::Module,
+    types::BasicMetadataTypeEnum,
+    types::BasicTypeEnum,
+    values::{BasicMetadataValueEnum, BasicValueEnum, CallableValue, FunctionValue, PointerValue},
+    AddressSpace, IntPredicate, OptimizationLevel,
+};
+
+use crate::{
+    ast::{builtin::BuiltinData, *},
+    env::{Env, NameEnv},
+};
+
+struct CodegenHelper<'a> {
+    context: &'a Context,
+    module: Module<'a>,
+    builder: Builder<'a>,
+}
+
+impl<'a> CodegenHelper<'a> {
+    fn new(context: &'a Context) -> Self {
+        let module = context.create_module("main");
+        let builder = context.create_builder();
+
+        Self {
+            context,
+            module,
+            builder,
+        }
+    }
+
+    fn add_function(&mut self, func: &Func, name_env: &NameEnv) -> FunctionValue<'a> {
+        let func_type = make_llvm_type_from_simple_type(self.context, &SimpleType::from(&func.typ))
+            .into_pointer_type()
+            .get_element_type()
+            .into_function_type();
+        let func_name = name_env.lookup(func.typ.ident());
+        self.module
+            .add_function(func_name.as_str(), func_type, None)
+    }
+
+    fn build_function_body(
+        &mut self,
+        func: Func,
+        name_env: &NameEnv,
+        func_env: &Env<FunctionValue<'a>>,
+        value_env: &mut Env<PointerValue<'a>>,
+    ) {
+        let function = func_env.lookup(func.typ.ident());
+        let entry_basic_block = self.context.append_basic_block(*function, "entry");
+        self.builder.position_at_end(entry_basic_block);
+
+        let mut func_type = func.typ;
+        let mut value_env = value_env.clone();
+        for param_value in function.get_param_iter() {
+            let (param_type, func_type_) = match func_type {
+                Type::FuncType(_, type1, type2, _) => (*type1, *type2),
+                Type::IntType(_, _, _) => unreachable!(),
+            };
+            func_type = func_type_;
+            let param_ident = param_type.ident();
+            let param_name = name_env.lookup(param_type.ident());
+            let param_type =
+                make_llvm_type_from_simple_type(self.context, &SimpleType::from(param_type));
+            let param_value = match param_type {
+                BasicMetadataTypeEnum::IntType(i) => {
+                    let param = self.builder.build_alloca(i, &param_name);
+                    self.builder.build_store(param, param_value);
+                    param
+                }
+                BasicMetadataTypeEnum::PointerType(p) => {
+                    let param = self.builder.build_alloca(p, &param_name);
+                    param
+                }
+                _ => unreachable!(),
+            };
+            value_env.insert(param_ident, param_value);
+        }
+
+        let ret_expr = self.build_expr(func.body, name_env, &value_env, function);
+        self.builder.build_return(Some(&ret_expr));
+    }
+
+    fn build_expr(
+        &self,
+        expr: Expr,
+        name_env: &NameEnv,
+        value_env: &Env<PointerValue<'a>>,
+        current_function: &FunctionValue,
+    ) -> BasicValueEnum<'a> {
+        match expr {
+            Expr::Num(n, _) => {
+                BasicValueEnum::IntValue(self.context.i32_type().const_int(n as u64, false))
+            }
+            Expr::Var(ident, _) => {
+                let var = value_env.lookup(ident).clone();
+                let name = format!("{}.load", name_env.lookup(ident));
+                if var.get_type().get_element_type().is_function_type() {
+                    var.into()
+                } else {
+                    self.builder.build_load(var, name.as_str())
+                }
+            }
+            Expr::Ifz(cond, then_expr, else_expr, _) => {
+                let cond_expr = self.build_expr(*cond, name_env, value_env, current_function);
+                let cond_value = self.builder.build_int_compare(
+                    IntPredicate::EQ,
+                    cond_expr.into_int_value(),
+                    self.context.i32_type().const_int(0, false),
+                    "cond",
+                );
+                let then_block = self
+                    .context
+                    .append_basic_block(*current_function, "then_block");
+                let else_block = self
+                    .context
+                    .append_basic_block(*current_function, "else_block");
+                let merge_block = self
+                    .context
+                    .append_basic_block(*current_function, "merge_block");
+                self.builder
+                    .build_conditional_branch(cond_value, then_block, else_block);
+
+                // then block
+                self.builder.position_at_end(then_block);
+                let then_ret = self.build_expr(*then_expr, name_env, value_env, current_function);
+                self.builder.build_unconditional_branch(merge_block);
+                let then_block = self.builder.get_insert_block().unwrap();
+
+                // else block
+                self.builder.position_at_end(else_block);
+                let else_ret = self.build_expr(*else_expr, name_env, value_env, current_function);
+                self.builder.build_unconditional_branch(merge_block);
+                let else_block = self.builder.get_insert_block().unwrap();
+
+                // merge block
+                self.builder.position_at_end(merge_block);
+                let phi = self.builder.build_phi(then_ret.get_type(), "phi");
+                phi.add_incoming(&[(&then_ret, then_block), (&else_ret, else_block)]);
+                phi.as_basic_value()
+            }
+            Expr::Let(ident, e1, e2, _) => {
+                let e1_value = self.build_expr(*e1, name_env, value_env, current_function);
+                let var_value = match e1_value.get_type() {
+                    BasicTypeEnum::IntType(i) => {
+                        self.builder.build_alloca(i, name_env.lookup(ident))
+                    }
+                    BasicTypeEnum::PointerType(p) => {
+                        self.builder.build_alloca(p, name_env.lookup(ident))
+                    }
+                    _ => unreachable!(),
+                };
+                self.builder.build_store(var_value, e1_value);
+                let mut value_env = value_env.clone();
+                value_env.insert(ident, var_value);
+                self.build_expr(*e2, name_env, &value_env, current_function)
+            }
+            Expr::App(mut e1, e2, _) => {
+                // TODO: 部分適用の場合についても実装する
+                let mut args: Vec<BasicMetadataValueEnum> = vec![self
+                    .build_expr(*e2, name_env, value_env, current_function)
+                    .into()];
+                while let Expr::App(e1_, e2, _) = *e1 {
+                    args.push(
+                        self.build_expr(*e2, name_env, value_env, current_function)
+                            .into(),
+                    );
+                    e1 = e1_
+                }
+                let args = args.into_iter().rev().collect();
+
+                match *e1 {
+                    Expr::Var(ident, _) if ident.is_builtin => self.build_builtin_call(ident, args),
+                    _ => {
+                        let func_value: CallableValue = self
+                            .build_expr(*e1, name_env, value_env, current_function)
+                            .into_pointer_value()
+                            .try_into()
+                            .unwrap();
+                        self.builder
+                            .build_call(func_value, args.as_slice(), "ret")
+                            .try_as_basic_value()
+                            .left()
+                            .unwrap()
+                    }
+                }
+            }
+        }
+    }
+
+    fn build_builtin_call(
+        &self,
+        ident: Ident,
+        args: Vec<BasicMetadataValueEnum<'a>>,
+    ) -> BasicValueEnum<'a> {
+        let builtin = BuiltinData::instance();
+        if builtin.or_ident == ident {
+            self.builder
+                .build_or(args[0].into_int_value(), args[1].into_int_value(), "or")
+                .into()
+        } else if builtin.and_ident == ident {
+            self.builder
+                .build_and(args[0].into_int_value(), args[1].into_int_value(), "and")
+                .into()
+        } else if builtin.eq_ident == ident {
+            self.builder
+                .build_int_compare(
+                    IntPredicate::EQ,
+                    args[0].into_int_value(),
+                    args[1].into_int_value(),
+                    "eq",
+                )
+                .into()
+        } else if builtin.neq_ident == ident {
+            self.builder
+                .build_int_compare(
+                    IntPredicate::NE,
+                    args[0].into_int_value(),
+                    args[1].into_int_value(),
+                    "ne",
+                )
+                .into()
+        } else if builtin.lt_ident == ident {
+            self.builder
+                .build_int_compare(
+                    IntPredicate::SLT,
+                    args[0].into_int_value(),
+                    args[1].into_int_value(),
+                    "lt",
+                )
+                .into()
+        } else if builtin.leq_ident == ident {
+            self.builder
+                .build_int_compare(
+                    IntPredicate::SLE,
+                    args[0].into_int_value(),
+                    args[1].into_int_value(),
+                    "le",
+                )
+                .into()
+        } else if builtin.gt_ident == ident {
+            self.builder
+                .build_int_compare(
+                    IntPredicate::SGT,
+                    args[0].into_int_value(),
+                    args[1].into_int_value(),
+                    "gt",
+                )
+                .into()
+        } else if builtin.geq_ident == ident {
+            self.builder
+                .build_int_compare(
+                    IntPredicate::SGE,
+                    args[0].into_int_value(),
+                    args[1].into_int_value(),
+                    "ge",
+                )
+                .into()
+        } else if builtin.add_ident == ident {
+            self.builder
+                .build_int_add(args[0].into_int_value(), args[1].into_int_value(), "add")
+                .into()
+        } else if builtin.sub_ident == ident {
+            self.builder
+                .build_int_sub(args[0].into_int_value(), args[1].into_int_value(), "sub")
+                .into()
+        } else if builtin.mult_ident == ident {
+            self.builder
+                .build_int_mul(args[0].into_int_value(), args[1].into_int_value(), "mul")
+                .into()
+        } else if builtin.div_ident == ident {
+            self.builder
+                .build_int_signed_div(args[0].into_int_value(), args[1].into_int_value(), "div")
+                .into()
+        } else if builtin.rem_ident == ident {
+            self.builder
+                .build_int_signed_rem(args[0].into_int_value(), args[1].into_int_value(), "rem")
+                .into()
+        } else {
+            unimplemented!()
+        }
+    }
+
+    fn run(&self) {
+        let execution_engine = self
+            .module
+            .create_jit_execution_engine(OptimizationLevel::Aggressive)
+            .unwrap();
+        let result = unsafe {
+            execution_engine
+                .get_function::<unsafe extern "C" fn(i32) -> i32>("main")
+                .unwrap()
+                .call(42)
+        };
+        eprintln!("result: {}", result);
+    }
+}
+
+fn make_llvm_type_from_simple_type<'a>(
+    context: &'a Context,
+    mut simple_type: &SimpleType,
+) -> BasicMetadataTypeEnum<'a> {
+    let mut param_types: Vec<BasicMetadataTypeEnum<'a>> = vec![];
+    while let SimpleType::FuncType(from_type, to_type) = simple_type {
+        param_types.push(make_llvm_type_from_simple_type(context, from_type));
+        simple_type = to_type;
+    }
+
+    if param_types.is_empty() {
+        context.i32_type().into()
+    } else {
+        context
+            .i32_type()
+            .fn_type(param_types.as_slice(), false)
+            .ptr_type(AddressSpace::Generic)
+            .into()
+    }
+}
+
+pub fn program(program: Program, name_env: &NameEnv) {
+    let context = Context::create();
+    let mut helper = CodegenHelper::new(&context);
+
+    let mut func_env = Env::empty();
+    let mut value_env = Env::empty();
+    for func in &program.funcs {
+        let func_value = helper.add_function(func, name_env);
+        func_env.insert(func.typ.ident(), func_value);
+        value_env.insert(
+            func.typ.ident(),
+            func_value.as_global_value().as_pointer_value(),
+        );
+    }
+
+    for func in program.funcs {
+        helper.build_function_body(func, name_env, &func_env, &mut value_env);
+    }
+
+    helper.run();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ extern crate pest;
 extern crate pest_derive;
 
 mod ast;
+mod codegen;
 mod env;
 mod error_report_util;
 mod parse;
@@ -35,5 +36,5 @@ fn main() {
         err.print(&name_env, &src_lines).unwrap();
         std::process::exit(-1);
     });
-    println!("well typed!");
+    codegen::program(program, &name_env);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,5 +36,5 @@ fn main() {
         err.print(&name_env, &src_lines).unwrap();
         std::process::exit(-1);
     });
-    codegen::program(program, &name_env);
+    std::process::exit(codegen::program(program, &name_env));
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -92,6 +92,11 @@ fn program_from_pair(pair: Pair<Rule>) -> Result<(Program, NameEnv), ParseError>
     let mut name_env = NameEnv::empty();
     let mut name_to_ident = HashMap::new();
 
+    // builtin functions
+    let builtin_data = builtin::BuiltinData::instance();
+    name_env.insert(builtin_data.print_bool_ident, "print_bool".to_string());
+    name_to_ident.insert("print_bool".to_string(), builtin_data.print_bool_ident);
+
     let mut func_later_pairss = vec![];
 
     while let Some(func_pair) = pairs.next() {
@@ -410,6 +415,8 @@ fn primary_term_from_pair(
             let n = integer_constant_from_pair(pair);
             Ok((logic::Term::Num(n, info), NameEnv::empty()))
         }
+        Rule::kw_true => Ok((logic::Term::Num(0, info), NameEnv::empty())),
+        Rule::kw_false => Ok((logic::Term::Num(1, info), NameEnv::empty())),
         Rule::left_paren => {
             let e = additive_term_from_pair(pairs.next().unwrap(), name_to_ident)?;
             assert_eq!(pairs.next().unwrap().as_rule(), Rule::right_paren);

--- a/src/parse/grammar.pest
+++ b/src/parse/grammar.pest
@@ -19,7 +19,7 @@ binop_term = {
     (left_paren ~ term ~ right_paren) }
 additive_term = { multive_term ~ ((plus | minus) ~ multive_term)* }
 multive_term = { primary_term ~ ((ast | slash | percent) ~ primary_term)* }
-primary_term = { name | constant | left_paren ~ additive_term ~ right_paren }
+primary_term = { name | constant | kw_true | kw_false | left_paren ~ additive_term ~ right_paren }
 
 expr = {
     let_expr |

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -64,6 +64,7 @@ fn parse_program_test() {
                 info: Info::Dummy,
             },
             vec![
+                (Ident::builtin_ident_with_id(13), "print_bool".to_string()),
                 (Ident::with_id(init_id), "hoge".to_string()),
                 (Ident::with_id(init_id + 1), "fuga".to_string()),
                 (Ident::with_id(init_id + 2), "x".to_string()),


### PR DESCRIPTION
部分適用を含まないコードについて，LLVM IR を構築して JIT コンパイル & 実行するやつを実装しました．

#### 実装できていることの確認方法
`example-codes/well-typed` 以下の yil プログラムを与えて想定通りの挙動をすることを確認しました．
例えば
- `$ cargo run ./example-codes/well-typed/sum.yil` を実行して，ステータスコード 6 で異常終了することを確かめる
- `$ cargo run ./example-codes/well-typed/even_odd.yil` を実行すると，`true` と出力して正常終了することを確かめる
